### PR TITLE
config for the graylog URI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,13 @@ docker_graylog_web_port: 9000
 # publish the above port, if true
 docker_graylog_enable_web_host_port: false
 
+# If you run graylog behind a loadbalancer, you'll need to set this
+# to the actual address of the API.
+# example value: "https://mygraylogserver.example.com/api/"
+docker_graylog_rest_transport_uri: false
+# (you probably don't need to change this)
+docker_graylog_rest_listen_uri: "http://0.0.0.0:9000/api/"
+
 docker_graylog_network: graylog
 
 # optional LDAP authentication

--- a/templates/graylog.conf.j2
+++ b/templates/graylog.conf.j2
@@ -79,7 +79,7 @@ plugin_dir = /usr/share/graylog/plugin
 
 # REST API listen URI. Must be reachable by other Graylog server nodes if you run a cluster.
 # When using Graylog Collectors, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
-rest_listen_uri = http://0.0.0.0:9000/api/
+rest_listen_uri = {{ docker_graylog_rest_listen_uri }}
 
 # REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
 # is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
@@ -88,7 +88,9 @@ rest_listen_uri = http://0.0.0.0:9000/api/
 # You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
 # the scheme, host name or URI.
 # This must not contain a wildcard address (0.0.0.0).
-#rest_transport_uri = http://192.168.1.1:9000/api/
+{% if docker_graylog_rest_transport_uri %}
+rest_transport_uri = {{ docker_graylog_rest_transport_uri }}
+{% endif %}
 
 # Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.
 # If these are disabled, modern browsers will not be able to retrieve resources from the server.
@@ -134,7 +136,7 @@ web_listen_uri = http://0.0.0.0:9000/
 
 # Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
 # Default: $rest_transport_uri
-web_endpoint_uri = http://127.0.0.1:{{ docker_graylog_web_port }}/api
+#web_endpoint_uri = http://127.0.0.1:{{ docker_graylog_web_port }}/api
 
 # Enable CORS headers for the web interface. This is necessary for JS-clients accessing the server directly.
 # If these are disabled, modern browsers will not be able to retrieve resources from the server.


### PR DESCRIPTION
so that the frontend finds the backend, if it's running behind a loadbalancer