### PR TITLE
fix ansible-galaxy warnings; set json-file log driver for graylog itself

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  author: Richard Wossal
   description: role to install graylog for/via docker
   license:
     - BSD

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
   command: "docker network create --attachable --driver=overlay {{ docker_graylog_network }}"
   args:
     warn: false
+  ignore_errors: true
 
 - name: Create docker network (non-swarm)
   when: not docker_graylog_use_swarm

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,6 @@
   command: "docker network create --attachable --driver=overlay {{ docker_graylog_network }}"
   args:
     warn: false
-  ignore_errors: true
 
 - name: Create docker network (non-swarm)
   when: not docker_graylog_use_swarm
@@ -67,7 +66,7 @@
     docker ps -q --filter "label=org.label-schema.name=Graylog Docker Image" \
                  --filter "health=healthy"
   register: healthy_graylog
-  until: healthy_graylog.stdout != ""
+  until: healthy_graylog.stdout
   delay: 5
   retries: 20
   changed_when: false

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -27,6 +27,8 @@ services:
   # Graylog: https://hub.docker.com/r/graylog/graylog/
   graylog:
     image: "{{ docker_graylog_image }}:{{ docker_graylog_tag }}"
+    logging:
+      driver: "json-file"
     networks:
       - {{ docker_graylog_network }}
     volumes:


### PR DESCRIPTION
~~apparently the `not in docker_nets.stdout` doesn't always work, for some reason...~~ **edit** works now, actually. Not sure what went wrong there.