### PR TITLE
remove default "additional default group" for ldap

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,5 +48,5 @@ docker_graylog_ldap_default_group: "Reader"
 docker_graylog_ldap_group_mapping: {}
 docker_graylog_ldap_group_search_base: ""
 docker_graylog_ldap_group_id_attribute: ""
-docker_graylog_ldap_additional_default_groups: [ "Developer" ]
+docker_graylog_ldap_additional_default_groups: []
 docker_graylog_ldap_group_search_pattern: ""


### PR DESCRIPTION
if that group doesn't exist in graylog, this would break ldap login

for https://github.com/pngmbh/issues/issues/106#issuecomment-459046635